### PR TITLE
Additional adjustments for final zig 0.14 release

### DIFF
--- a/s2s.zig
+++ b/s2s.zig
@@ -81,8 +81,8 @@ fn serializeRecursive(stream: anytype, comptime T: type, value: T) @TypeOf(strea
         .pointer => |ptr| {
             if (ptr.sentinel() != null) @compileError("Sentinels are not supported yet!");
             switch (ptr.size) {
-                .One => try serializeRecursive(stream, ptr.child, value.*),
-                .Slice => {
+                .one => try serializeRecursive(stream, ptr.child, value.*),
+                .slice => {
                     try stream.writeInt(u64, value.len, .little);
                     if (ptr.child == u8) {
                         try stream.writeAll(value);
@@ -92,8 +92,8 @@ fn serializeRecursive(stream: anytype, comptime T: type, value: T) @TypeOf(strea
                         }
                     }
                 },
-                .C => unreachable,
-                .Many => unreachable,
+                .c => unreachable,
+                .many => unreachable,
             }
         },
         .array => |arr| {
@@ -230,7 +230,7 @@ fn recursiveDeserialize(
         .pointer => |ptr| {
             if (ptr.sentinel() != null) @compileError("Sentinels are not supported yet!");
             switch (ptr.size) {
-                .One => {
+                .one => {
                     const pointer = try allocator.?.create(ptr.child);
                     errdefer allocator.?.destroy(pointer);
 
@@ -238,7 +238,7 @@ fn recursiveDeserialize(
 
                     target.* = pointer;
                 },
-                .Slice => {
+                .slice => {
                     const length = std.math.cast(usize, try stream.readInt(u64, .little)) orelse return error.UnexpectedData;
 
                     const slice = try allocator.?.alloc(ptr.child, length);
@@ -254,8 +254,8 @@ fn recursiveDeserialize(
 
                     target.* = slice;
                 },
-                .C => unreachable,
-                .Many => unreachable,
+                .c => unreachable,
+                .many => unreachable,
             }
         },
         .array => |arr| {
@@ -546,16 +546,16 @@ fn computeTypeHashInternal(hasher: *TypeHashFn, comptime T: type) void {
             if (ptr.is_volatile) @compileError("Serializing volatile pointers is most likely a mistake.");
             if (ptr.sentinel() != null) @compileError("Sentinels are not supported yet!");
             switch (ptr.size) {
-                .One => {
+                .one => {
                     hasher.update("pointer");
                     computeTypeHashInternal(hasher, ptr.child);
                 },
-                .Slice => {
+                .slice => {
                     hasher.update("slice");
                     computeTypeHashInternal(hasher, ptr.child);
                 },
-                .C => @compileError("C-pointers are not supported"),
-                .Many => @compileError("Many-pointers are not supported"),
+                .c => @compileError("C-pointers are not supported"),
+                .many => @compileError("Many-pointers are not supported"),
             }
         },
         .array => |arr| {

--- a/s2s.zig
+++ b/s2s.zig
@@ -79,7 +79,7 @@ fn serializeRecursive(stream: anytype, comptime T: type, value: T) @TypeOf(strea
             }
         },
         .pointer => |ptr| {
-            if (ptr.sentinel != null) @compileError("Sentinels are not supported yet!");
+            if (ptr.sentinel() != null) @compileError("Sentinels are not supported yet!");
             switch (ptr.size) {
                 .One => try serializeRecursive(stream, ptr.child, value.*),
                 .Slice => {
@@ -104,7 +104,7 @@ fn serializeRecursive(stream: anytype, comptime T: type, value: T) @TypeOf(strea
                     try serializeRecursive(stream, arr.child, item);
                 }
             }
-            if (arr.sentinel != null) @compileError("Sentinels are not supported yet!");
+            if (arr.sentinel() != null) @compileError("Sentinels are not supported yet!");
         },
         .@"struct" => |str| {
             // we can safely ignore the struct layout here as we will serialize the data by field order,
@@ -228,7 +228,7 @@ fn recursiveDeserialize(
             @truncate(try stream.readInt(AlignedInt(T), .little)),
 
         .pointer => |ptr| {
-            if (ptr.sentinel != null) @compileError("Sentinels are not supported yet!");
+            if (ptr.sentinel() != null) @compileError("Sentinels are not supported yet!");
             switch (ptr.size) {
                 .One => {
                     const pointer = try allocator.?.create(ptr.child);
@@ -544,7 +544,7 @@ fn computeTypeHashInternal(hasher: *TypeHashFn, comptime T: type) void {
         },
         .pointer => |ptr| {
             if (ptr.is_volatile) @compileError("Serializing volatile pointers is most likely a mistake.");
-            if (ptr.sentinel != null) @compileError("Sentinels are not supported yet!");
+            if (ptr.sentinel() != null) @compileError("Sentinels are not supported yet!");
             switch (ptr.size) {
                 .One => {
                     hasher.update("pointer");
@@ -559,7 +559,7 @@ fn computeTypeHashInternal(hasher: *TypeHashFn, comptime T: type) void {
             }
         },
         .array => |arr| {
-            if (arr.sentinel != null) @compileError("Sentinels are not supported yet!");
+            if (arr.sentinel() != null) @compileError("Sentinels are not supported yet!");
             hasher.update(&intToLittleEndianBytes(@as(u64, arr.len)));
             computeTypeHashInternal(hasher, arr.child);
         },


### PR DESCRIPTION
- **fix: use .sentinel() type helpers to obtain sentinel value**
- **fix: use correct lowercase names of builtin.Type.Pointer.Size variants**
