### PR TITLE
Changes for Zig 0.14: zon and tests pass

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .s2s,
     .version = "0.0.1",
-	.fingerprint = 0x8d8a7bec8d1adfaa,
+    .fingerprint = 0x8d8a7bec8d1adfaa,
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = .s2s,
+    .version = "0.0.1",
+	.fingerprint = 0x8d8a7bec8d1adfaa,
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "s2s.zig",
+    },
+}

--- a/s2s.zig
+++ b/s2s.zig
@@ -373,20 +373,20 @@ fn recursiveFree(allocator: std.mem.Allocator, comptime T: type, value: *T) void
         // Composite types:
         .pointer => |ptr| {
             switch (ptr.size) {
-                .One => {
+                .one => {
                     const mut_ptr = @constCast(value.*);
                     recursiveFree(allocator, ptr.child, mut_ptr);
                     allocator.destroy(mut_ptr);
                 },
-                .Slice => {
+                .slice => {
                     const mut_slice = makeMutableSlice(ptr.child, value.*);
                     for (mut_slice) |*item| {
                         recursiveFree(allocator, ptr.child, item);
                     }
                     allocator.free(mut_slice);
                 },
-                .C => unreachable,
-                .Many => unreachable,
+                .c => unreachable,
+                .many => unreachable,
             }
         },
         .array => |arr| {


### PR DESCRIPTION
Please take a look. Maybe this is useful:

* PR adds a build.zig.zon to make it easier to use this package with zig
fetch. 
* PR also includes a small fix to make zig build test pass as the
builtin.Type.Point.Size has downcased its members.
